### PR TITLE
Feature/food details

### DIFF
--- a/app/src/main/java/com/example/henriqueribeirodealmeida/nutre/Adapters/AddedFoodAdapter.java
+++ b/app/src/main/java/com/example/henriqueribeirodealmeida/nutre/Adapters/AddedFoodAdapter.java
@@ -61,7 +61,7 @@ public class AddedFoodAdapter extends ArrayAdapter<Food> {
         nameView.setText(currentItem.getName());
 
         TextView quantityView = itemView.findViewById(R.id.item_info);
-        int quantity = (int) currentItem.getQuantityPerUnit();
+        final int quantity = (int) currentItem.getQuantityPerUnit();
         String quantityOutput = "Qtd.: " + quantity + " (" + currentItem.getMeasure() + ")";
         quantityView.setText(quantityOutput);
 
@@ -85,6 +85,7 @@ public class AddedFoodAdapter extends ArrayAdapter<Food> {
                                             Bundle bundle = new Bundle();
                                             bundle.putParcelable("food", getFoodDetails(currentItem.getName()));
                                             bundle.putString("caller", "AddedFoodAdapter");
+                                            bundle.putDouble("quantity", quantity);
                                             intent.putExtra("bundle", bundle);
                                             context.startActivity(intent);
 

--- a/app/src/main/java/com/example/henriqueribeirodealmeida/nutre/FoodDetailsActivity.java
+++ b/app/src/main/java/com/example/henriqueribeirodealmeida/nutre/FoodDetailsActivity.java
@@ -76,7 +76,7 @@ public class FoodDetailsActivity extends AppCompatActivity{
             summaryItems.add(new Nutrient());
         }
         if (bundle.getString("caller").equals("AddedFoodAdapter")){
-            homeView.setVisibility(View.GONE);
+            homeView.setVisibility(View.INVISIBLE);
             double totalQuantity;
             double quantity = bundle.getDouble("quantity");
 
@@ -168,7 +168,6 @@ public class FoodDetailsActivity extends AppCompatActivity{
         summaryItems.get(16).setName("Tiamina");
         summaryItems.get(16).setValue((int) (summaryValues.getThiamine() * factor));
         summaryItems.get(16).setMeasure(" mg");
-
     }
 
     private void setListViewHeight(ListView listView) {

--- a/app/src/main/java/com/example/henriqueribeirodealmeida/nutre/FoodDetailsActivity.java
+++ b/app/src/main/java/com/example/henriqueribeirodealmeida/nutre/FoodDetailsActivity.java
@@ -32,6 +32,7 @@ public class FoodDetailsActivity extends AppCompatActivity{
     private ArrayList<Nutrient> summaryItems;
     private FoodDetailsAdapter adapter;
     private ScrollView scrollContainer;
+    private double factor;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -46,8 +47,10 @@ public class FoodDetailsActivity extends AppCompatActivity{
         ListView nutrientsView = findViewById(R.id.nutrients);
         ImageView homeView = findViewById(R.id.home);
         scrollContainer = findViewById(R.id.scroll_container);
-
+        TextView quantityView = findViewById(R.id.quantity);
         nameView.setText(meal.getName());
+
+        factor = 1;
 
         summaryItems = new ArrayList<>();
         summaryValues = new SummaryValues(
@@ -72,6 +75,15 @@ public class FoodDetailsActivity extends AppCompatActivity{
         for (int i = 0; i < NUTRIENTS_COUNT; i++){
             summaryItems.add(new Nutrient());
         }
+        if (bundle.getString("caller").equals("AddedFoodAdapter")){
+            homeView.setVisibility(View.GONE);
+            double totalQuantity;
+            double quantity = bundle.getDouble("quantity");
+
+            totalQuantity = quantity * meal.getUnityMultiplier();
+            factor = totalQuantity / 100;
+            quantityView.setText("Composição em " + (int) totalQuantity + "g");
+        }
         setSummaryItems();
 
         adapter = new FoodDetailsAdapter(this, summaryItems);
@@ -86,79 +98,75 @@ public class FoodDetailsActivity extends AppCompatActivity{
                 startActivity(intent);
             }
         });
-
-        if (bundle.getString("caller").equals("AddedFoodAdapter")){
-            homeView.setVisibility(View.GONE);
-        }
     }
 
     private void setSummaryItems(){
         summaryItems.get(0).setName("Energia");
-        summaryItems.get(0).setValue((int) summaryValues.getEnergy());
+        summaryItems.get(0).setValue((int) (summaryValues.getEnergy() * factor));
         summaryItems.get(0).setMeasure(" kcal");
 
         summaryItems.get(1).setName("Carboidratos");
-        summaryItems.get(1).setValue((int) summaryValues.getCarbohydrate());
+        summaryItems.get(1).setValue((int) (summaryValues.getCarbohydrate() * factor));
         summaryItems.get(1).setMeasure(" g");
 
         summaryItems.get(2).setName("Proteína");
-        summaryItems.get(2).setValue((int) summaryValues.getProtein());
+        summaryItems.get(2).setValue((int) (summaryValues.getProtein() * factor));
         summaryItems.get(2).setMeasure(" g");
 
         summaryItems.get(3).setName("Gorduras Totais");
-        summaryItems.get(3).setValue((int) summaryValues.getTotalFat());
+        summaryItems.get(3).setValue((int) (summaryValues.getTotalFat() * factor));
         summaryItems.get(3).setMeasure(" g");
 
         summaryItems.get(4).setName("Gordura Saturada");
-        summaryItems.get(4).setValue((int) summaryValues.getSaturatedFat());
+        summaryItems.get(4).setValue((int) (summaryValues.getSaturatedFat() * factor));
         summaryItems.get(4).setMeasure(" g");
 
         summaryItems.get(5).setName("Gordura Trans");
-        summaryItems.get(5).setValue((int) summaryValues.getTransFat());
+        summaryItems.get(5).setValue((int) (summaryValues.getTransFat() * factor));
         summaryItems.get(5).setMeasure(" g");
 
         summaryItems.get(6).setName("Fibras");
-        summaryItems.get(6).setValue((int) summaryValues.getFibers());
+        summaryItems.get(6).setValue((int) (summaryValues.getFibers() * factor));
         summaryItems.get(6).setMeasure(" g");
 
         summaryItems.get(7).setName("Sódio");
-        summaryItems.get(7).setValue((int) summaryValues.getSodium());
+        summaryItems.get(7).setValue((int) (summaryValues.getSodium() * factor));
         summaryItems.get(7).setMeasure(" mg");
 
         summaryItems.get(8).setName("Vitamina C");
-        summaryItems.get(8).setValue((int) summaryValues.getVitaminC());
+        summaryItems.get(8).setValue((int) (summaryValues.getVitaminC() * factor));
         summaryItems.get(8).setMeasure(" mg");
 
         summaryItems.get(9).setName("Cálcio");
-        summaryItems.get(9).setValue((int) summaryValues.getCalcium());
+        summaryItems.get(9).setValue((int) (summaryValues.getCalcium() * factor));
         summaryItems.get(9).setMeasure(" mg");
 
         summaryItems.get(10).setName("Ferro");
-        summaryItems.get(10).setValue((int) summaryValues.getIron());
+        summaryItems.get(10).setValue((int) (summaryValues.getIron() * factor));
         summaryItems.get(10).setMeasure(" mg");
 
         summaryItems.get(11).setName("Vitamina A");
-        summaryItems.get(11).setValue((int) summaryValues.getVitaminA());
+        summaryItems.get(11).setValue((int) (summaryValues.getVitaminA() * factor));
         summaryItems.get(11).setMeasure(" µg");
 
-        summaryItems.get(12).setName("Celenio");
-        summaryItems.get(12).setValue((int) summaryValues.getSelenium());
+        summaryItems.get(12).setName("Selenio");
+        summaryItems.get(12).setValue((int) (summaryValues.getSelenium() * factor));
         summaryItems.get(12).setMeasure(" µg");
 
         summaryItems.get(13).setName("Potássio");
-        summaryItems.get(13).setValue((int) summaryValues.getPotassium());
+        summaryItems.get(13).setValue((int) (summaryValues.getPotassium() * factor));
         summaryItems.get(13).setMeasure(" g");
 
         summaryItems.get(14).setName("Magnésio");
-        summaryItems.get(14).setValue((int) summaryValues.getMagnesium());
+        summaryItems.get(14).setValue((int) (summaryValues.getMagnesium() * factor));
         summaryItems.get(14).setMeasure(" g");
 
         summaryItems.get(15).setName("Vitamina E");
-        summaryItems.get(15).setValue((int) summaryValues.getVitaminE());
+        summaryItems.get(15).setValue((int) (summaryValues.getVitaminE() * factor));
         summaryItems.get(15).setMeasure(" mg");
 
         summaryItems.get(16).setName("Tiamina");
-        summaryItems.get(16).setValue((int) summaryValues.getThiamine());
+        summaryItems.get(16).setValue((int) (summaryValues.getThiamine() * factor));
         summaryItems.get(16).setMeasure(" mg");
 
     }

--- a/app/src/main/res/layout/activity_food_details.xml
+++ b/app/src/main/res/layout/activity_food_details.xml
@@ -60,6 +60,7 @@
             android:background="@color/colorPrimaryDark" />
 
         <TextView
+            android:id="@+id/quantity"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="Composição em 100g"/>

--- a/app/src/main/res/layout/activity_food_details.xml
+++ b/app/src/main/res/layout/activity_food_details.xml
@@ -11,6 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
+        android:focusableInTouchMode="true"
         android:orientation="vertical">
 
         <ImageView


### PR DESCRIPTION
In NewMealActivity, when the user looks for the details of the specific added food, he's redirected to the FoodDetailsActivity which shows the nutrients of the specific quantity of food chosen previously by the user. The code has adaptations to treat the case of SearchActivity, in which food quantity is not passed by and it shows the default quantity (100g).
This pull request also contains a fix related to an old bug that was starting the FoodDetailsAcitvity in a position different from the start position.